### PR TITLE
fix library name on `README.md`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ Simple React + D3 wordcloud component with powerful features. Uses the [`d3-clou
 ## Install
 
 ```sh
-npm install react-wordcloud
+npm install @cyberblast/react-wordcloud
 ```
 
 Note that `react-wordcloud` requires `react^16.13.0` as a peer dependency.
@@ -18,7 +18,7 @@ Note that `react-wordcloud` requires `react^16.13.0` as a peer dependency.
 
 ```js
 import React from 'react';
-import ReactWordcloud from 'react-wordcloud';
+import ReactWordcloud from '@cyberblast/react-wordcloud';
 
 import 'tippy.js/dist/tippy.css';
 import 'tippy.js/animations/scale.css';


### PR DESCRIPTION
Replace all `react-wordcloud` to `@cyberblast/react-wordcloud`