### PR TITLE
Replaced Deprecated `defaultProps` to ES6 Syntax

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,10 +27,10 @@ export const defaultOptions = {
 };
 
 function ReactWordCloud({
-  callbacks,
+  callbacks = defaultCallbacks,
   maxWords = 100,
-  minSize,
-  options,
+  minSize = [300, 300],
+  options = defaultOptions,
   size: initialSize,
   words,
   ...rest
@@ -61,12 +61,5 @@ function ReactWordCloud({
 
   return <div ref={ref} style={{ height: '100%', width: '100%' }} {...rest} />;
 }
-
-ReactWordCloud.defaultProps = {
-  callbacks: defaultCallbacks,
-  maxWords: 100,
-  minSize: [300, 300],
-  options: defaultOptions,
-};
 
 export default ReactWordCloud;


### PR DESCRIPTION
To fix
![image](https://github.com/cyberblast/react-wordcloud/assets/46896789/d61fc5e9-bbaf-4f62-853e-ba1d96d9a8e3)
